### PR TITLE
Removed stdout flush for performance optimization, also fixes gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/target
+target/

--- a/servo_runner/runner.rs
+++ b/servo_runner/runner.rs
@@ -71,8 +71,7 @@ fn send_event(event: ServoEvent) -> std::io::Result<()> {
     let encoded = event.encode_to_vec();
     let len = (encoded.len() as u32).to_le_bytes();
     io::stdout().write_all(&len)?;
-    io::stdout().write_all(&encoded)?;
-    io::stdout().flush()
+    io::stdout().write_all(&encoded)
 }
 
 struct ServoWebViewDelegate {


### PR DESCRIPTION
Removes the explicit flush from stdout as suggested by #22. In my case this didn't lead to noticeable performance improvements tbh... I will keep debugging/profiling and I start thinking that moving to a shared memory buffer or - even better - a cross-prcess dmabuf, is the way to go... but it's a larger change (the dmabuf would also save us the time spent in glReadPixel).

Anyway, this is a first step that won't hurt.