### PR TITLE
Run Servo runner via self-re-exec instead of a separate binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,6 @@ edition = "2024"
 name = "servo_gtk"
 path = "servo_gtk/lib.rs"
 
-[[bin]]
-name = "servo-runner"
-path = "servo_runner/runner.rs"
-
 [[example]]
 name = "browser"
 path = "examples/browser.rs"

--- a/README.md
+++ b/README.md
@@ -30,13 +30,22 @@ Add to your `Cargo.toml`:
 servo-gtk = { path = "path/to/servo-gtk" }
 ```
 
-Then use in your code:
+Then use in your code. You **must** call `run_as_runner_if_requested()` as the
+very first thing in `main()`. The library runs Servo in a subprocess by
+re-executing your own binary; this call hands off to the Servo runner when the
+process was spawned as one, and returns immediately otherwise. No separate
+binary needs to be installed.
 
 ```rust
 use servo_gtk::WebView;
 
-let webview = WebView::new();
-webview.load_url("https://example.com");
+fn main() {
+    servo_gtk::run_as_runner_if_requested();
+
+    // ... your normal application startup ...
+    let webview = WebView::new();
+    webview.load_url("https://example.com");
+}
 ```
 
 ## Dependencies

--- a/examples/browser.rs
+++ b/examples/browser.rs
@@ -16,6 +16,10 @@ const LOGGER: glib::GlibLogger = glib::GlibLogger::new(
 );
 
 fn main() -> glib::ExitCode {
+    // If this process was spawned as the Servo runner subprocess, hand off to
+    // it immediately. This never returns when running as the runner.
+    servo_gtk::run_as_runner_if_requested();
+
     log::set_logger(&LOGGER).expect("logger already set");
     log::set_max_level(log::LevelFilter::Debug);
 

--- a/servo_gtk/lib.rs
+++ b/servo_gtk/lib.rs
@@ -4,7 +4,18 @@
 
 pub mod key_tables;
 pub mod proto_ipc;
+pub mod runner;
 pub mod servo_runner;
 pub mod web_view;
 
 pub use web_view::WebView;
+
+/// Hand off to the Servo runner subprocess if this process was spawned as one.
+///
+/// Consumers MUST call this as the very first statement in their `main()`.
+/// When the process was launched as the runner subprocess, this runs the
+/// runner and terminates the process without returning. Otherwise it returns
+/// immediately and normal application startup can proceed.
+pub fn run_as_runner_if_requested() {
+    runner::run_if_requested();
+}

--- a/servo_gtk/runner.rs
+++ b/servo_gtk/runner.rs
@@ -2,6 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+//! Servo runner subprocess entry point.
+//!
+//! The runner is not a separately installed binary. Instead, the library
+//! re-executes the consuming application's own executable with a marker
+//! argument (see [`RUNNER_ARG`]). The consumer is responsible for calling
+//! [`run_if_requested`] at the very start of its `main()` so that, when the
+//! process was spawned as a runner, control is handed off here and never
+//! returns to the normal application startup path.
+
 use std::io::{self, Read, Write};
 use std::rc::Rc;
 
@@ -22,10 +31,42 @@ use std::sync::mpsc::Receiver;
 use std::thread;
 use url::Url;
 
-use servo_gtk::proto_ipc::{
+use crate::proto_ipc::{
     CursorChanged, FrameReady, LogLevel, LogMessage, ServoAction, ServoEvent, servo_action,
     servo_event,
 };
+
+/// Marker argument used to signal that the process should run as a Servo
+/// runner subprocess rather than as the host application.
+pub const RUNNER_ARG: &str = "--servo-gtk-runner";
+
+/// If the current process was spawned as a Servo runner (i.e. its arguments
+/// contain [`RUNNER_ARG`]), run the runner loop and terminate the process,
+/// never returning. Otherwise, return immediately so normal application
+/// startup can proceed.
+///
+/// Consumers MUST call this as the very first thing in `main()`:
+///
+/// ```ignore
+/// fn main() {
+///     servo_gtk::run_as_runner_if_requested();
+///     // ... normal application startup ...
+/// }
+/// ```
+pub fn run_if_requested() {
+    // Only consider arguments before a `--` separator: by convention anything
+    // after `--` is positional/escaped and must not be interpreted as an
+    // option. The library always passes `RUNNER_ARG` as a regular argument
+    // when spawning, so it will always appear before any `--`.
+    let is_runner = std::env::args()
+        .skip(1)
+        .take_while(|arg| arg != "--")
+        .any(|arg| arg == RUNNER_ARG);
+    if is_runner {
+        run();
+        std::process::exit(0);
+    }
+}
 
 struct EventLogger {
     sender: std::sync::mpsc::Sender<LogMessage>,
@@ -182,12 +223,12 @@ fn spawn_stdin_channel() -> Receiver<ServoAction> {
     rx
 }
 
-fn convert_location(proto_location: servo_gtk::proto_ipc::Location) -> Location {
+fn convert_location(proto_location: crate::proto_ipc::Location) -> Location {
     match proto_location {
-        servo_gtk::proto_ipc::Location::Standard => Location::Standard,
-        servo_gtk::proto_ipc::Location::Left => Location::Left,
-        servo_gtk::proto_ipc::Location::Right => Location::Right,
-        servo_gtk::proto_ipc::Location::Numpad => Location::Numpad,
+        crate::proto_ipc::Location::Standard => Location::Standard,
+        crate::proto_ipc::Location::Left => Location::Left,
+        crate::proto_ipc::Location::Right => Location::Right,
+        crate::proto_ipc::Location::Numpad => Location::Numpad,
     }
 }
 
@@ -199,17 +240,17 @@ fn convert_key_event(
     modifiers: u32,
     state: KeyState,
 ) -> KeyboardEvent {
-    let key = match servo_gtk::proto_ipc::KeyType::try_from(key_type)
-        .unwrap_or(servo_gtk::proto_ipc::KeyType::Character)
+    let key = match crate::proto_ipc::KeyType::try_from(key_type)
+        .unwrap_or(crate::proto_ipc::KeyType::Character)
     {
-        servo_gtk::proto_ipc::KeyType::Character => Key::Character(key_str),
-        servo_gtk::proto_ipc::KeyType::Named => {
+        crate::proto_ipc::KeyType::Character => Key::Character(key_str),
+        crate::proto_ipc::KeyType::Named => {
             Key::Named(NamedKey::from_str(&key_str).unwrap_or(NamedKey::Unidentified))
         }
     };
     let location = convert_location(
-        servo_gtk::proto_ipc::Location::try_from(location)
-            .unwrap_or(servo_gtk::proto_ipc::Location::Standard),
+        crate::proto_ipc::Location::try_from(location)
+            .unwrap_or(crate::proto_ipc::Location::Standard),
     );
     let modifiers = Modifiers::from_bits_truncate(modifiers);
     // TODO: Convert key_code to proper Code enum value
@@ -218,7 +259,9 @@ fn convert_key_event(
     KeyboardEvent::new_without_event(state, key, code, location, modifiers, false, false)
 }
 
-fn main() {
+/// Run the Servo runner event loop. This blocks until a shutdown action is
+/// received or the IPC pipes are closed.
+pub fn run() {
     let (event_logger, log_receiver) = EventLogger::new();
 
     log::set_logger(Box::leak(Box::new(event_logger))).expect("Failed to set logger");

--- a/servo_gtk/servo_runner.rs
+++ b/servo_gtk/servo_runner.rs
@@ -44,14 +44,19 @@ impl ServoRunner {
     pub fn new() -> Self {
         let launcher =
             SubprocessLauncher::new(SubprocessFlags::STDIN_PIPE | SubprocessFlags::STDOUT_PIPE);
+
+        // Re-execute this same executable with a marker argument so it starts
+        // as the Servo runner subprocess. The consuming application is
+        // responsible for calling `servo_gtk::run_as_runner_if_requested()` at
+        // the start of `main()` to dispatch to the runner. This removes any
+        // need to install a separate binary or invoke `cargo`.
+        let current_exe = std::env::current_exe().expect("Failed to get current executable path");
         let subprocess = launcher
             .spawn(&[
-                OsStr::new("cargo"),
-                OsStr::new("run"),
-                OsStr::new("--bin"),
-                OsStr::new("servo-runner"),
+                current_exe.as_os_str(),
+                OsStr::new(crate::runner::RUNNER_ARG),
             ])
-            .expect("Failed to spawn servo-runner process");
+            .expect("Failed to spawn servo runner process");
 
         let stdin = subprocess.stdin_pipe().expect("Failed to get stdin");
         let stdout = subprocess.stdout_pipe().expect("Failed to get stdout");


### PR DESCRIPTION
Move the runner event loop into the library (servo_gtk::runner) and have the library re-execute the consuming application's own executable with a marker argument, instead of spawning `cargo run --bin servo-runner`.

Consumers call `servo_gtk::run_as_runner_if_requested()` at the start of main() to dispatch to the runner. This removes the need for a separate installed binary or a cargo/workspace dependency at runtime.

- Add servo_gtk/runner.rs with run() and run_if_requested()
- Spawn current_exe() + --servo-gtk-runner in ServoRunner::new()
- Remove the standalone servo-runner [[bin]] target
- Update example and README to call the guard first in main()