### PR TITLE
Add navigation observability API to WebView

### DIFF
--- a/examples/browser.rs
+++ b/examples/browser.rs
@@ -5,7 +5,7 @@
 use glib::info;
 use gtk::prelude::*;
 use gtk::{Application, ApplicationWindow, Box, Entry, Orientation, glib};
-use servo_gtk::WebView;
+use servo_gtk::{LoadEvent, WebView};
 use std::ptr;
 
 const G_LOG_DOMAIN: &str = "ServoGtkBrowser";
@@ -64,6 +64,9 @@ fn main() -> glib::ExitCode {
         let reload_button = gtk::Button::from_icon_name("view-refresh");
         reload_button.set_tooltip_text(Some("Reload"));
 
+        let spinner = gtk::Spinner::new();
+        spinner.set_tooltip_text(Some("Loading"));
+
         let web_view = WebView::new();
         web_view.set_hexpand(true);
         web_view.set_vexpand(true);
@@ -89,10 +92,36 @@ fn main() -> glib::ExitCode {
             web_view_clone.go_forward();
         });
 
+        // Keep the URL entry in sync with the actual page URI via
+        // `notify::uri`. This is how a redirect would be observed.
+        let url_entry_clone = url_entry.clone();
+        web_view.connect_uri_notify(move |web_view| {
+            if let Some(uri) = web_view.uri() {
+                url_entry_clone.set_text(&uri);
+            }
+        });
+
+        // Reflect the page title in the window title via `notify::title`.
+        let window_clone = window.clone();
+        web_view.connect_title_notify(move |web_view| match web_view.title() {
+            Some(title) if !title.is_empty() => {
+                window_clone.set_title(Some(&format!("{title} — Servo GTK Browser")));
+            }
+            _ => window_clone.set_title(Some("Servo GTK Browser")),
+        });
+
+        // Show a spinner while a load is in progress via `load-changed`.
+        let spinner_clone = spinner.clone();
+        web_view.connect_load_changed(move |_web_view, event| match event {
+            LoadEvent::Started => spinner_clone.start(),
+            LoadEvent::Finished => spinner_clone.stop(),
+        });
+
         hbox.append(&back_button);
         hbox.append(&forward_button);
         hbox.append(&reload_button);
         hbox.append(&url_entry);
+        hbox.append(&spinner);
         vbox.append(&hbox);
         vbox.append(&web_view);
 

--- a/servo_gtk/lib.rs
+++ b/servo_gtk/lib.rs
@@ -8,7 +8,7 @@ pub mod runner;
 pub mod servo_runner;
 pub mod web_view;
 
-pub use web_view::WebView;
+pub use web_view::{LoadEvent, WebView};
 
 /// Hand off to the Servo runner subprocess if this process was spawned as one.
 ///

--- a/servo_gtk/runner.rs
+++ b/servo_gtk/runner.rs
@@ -20,6 +20,7 @@ use embedder_traits::{WebViewPoint, WebViewVector};
 use euclid::Point2D;
 use keyboard_types::{Code, Key, KeyState, Location, Modifiers, NamedKey};
 
+use servo::LoadStatus;
 use servo::{
     DeviceIntRect, DeviceVector2D, InputEvent, KeyboardEvent, MouseButton, MouseButtonAction,
     MouseButtonEvent, MouseMoveEvent, Scroll, ServoBuilder,
@@ -32,8 +33,8 @@ use std::thread;
 use url::Url;
 
 use crate::proto_ipc::{
-    CursorChanged, FrameReady, LogLevel, LogMessage, ServoAction, ServoEvent, servo_action,
-    servo_event,
+    CursorChanged, FrameReady, LoadEnd, LoadStart, LogLevel, LogMessage, ServoAction, ServoEvent,
+    TitleChanged, UrlChanged, servo_action, servo_event,
 };
 
 /// Marker argument used to signal that the process should run as a Servo
@@ -188,6 +189,51 @@ impl WebViewDelegate for ServoWebViewDelegate {
             })),
         };
         let _ = send_event(event);
+    }
+
+    fn notify_url_changed(&self, _webview: WebView, url: Url) {
+        let event = ServoEvent {
+            event: Some(servo_event::Event::UrlChanged(UrlChanged {
+                url: url.to_string(),
+            })),
+        };
+        let _ = send_event(event);
+    }
+
+    fn notify_page_title_changed(&self, _webview: WebView, title: Option<String>) {
+        let event = ServoEvent {
+            event: Some(servo_event::Event::TitleChanged(TitleChanged {
+                title: title.unwrap_or_default(),
+            })),
+        };
+        let _ = send_event(event);
+    }
+
+    fn notify_load_status_changed(&self, webview: WebView, status: LoadStatus) {
+        // Use the current URL of the webview as the payload; it may be `None`
+        // very early in a load, in which case we send an empty string.
+        let url = webview.url().map(|u| u.to_string()).unwrap_or_default();
+        if let Some(event) = load_status_to_event(status, url) {
+            let _ = send_event(event);
+        }
+    }
+}
+
+/// Map a Servo [`LoadStatus`] to the corresponding [`ServoEvent`], if any.
+///
+/// Per the servo-gtk IPC contract we only surface the start and completion of
+/// a load: `Started` becomes a [`LoadStart`] and `Complete` becomes a
+/// [`LoadEnd`]. The intermediate `HeadParsed` state has no dedicated event and
+/// maps to `None`.
+fn load_status_to_event(status: LoadStatus, url: String) -> Option<ServoEvent> {
+    match status {
+        LoadStatus::Started => Some(ServoEvent {
+            event: Some(servo_event::Event::LoadStart(LoadStart { url })),
+        }),
+        LoadStatus::Complete => Some(ServoEvent {
+            event: Some(servo_event::Event::LoadEnd(LoadEnd { url })),
+        }),
+        LoadStatus::HeadParsed => None,
     }
 }
 
@@ -465,5 +511,39 @@ pub fn run() {
 
         // FIXME: we need a better way to not have a busy loop
         std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_status_started_maps_to_load_start() {
+        let event = load_status_to_event(LoadStatus::Started, "https://example.com/".to_string());
+        match event.and_then(|e| e.event) {
+            Some(servo_event::Event::LoadStart(load_start)) => {
+                assert_eq!(load_start.url, "https://example.com/");
+            }
+            other => panic!("expected LoadStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_status_complete_maps_to_load_end() {
+        let event = load_status_to_event(LoadStatus::Complete, "https://example.com/".to_string());
+        match event.and_then(|e| e.event) {
+            Some(servo_event::Event::LoadEnd(load_end)) => {
+                assert_eq!(load_end.url, "https://example.com/");
+            }
+            other => panic!("expected LoadEnd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_status_head_parsed_maps_to_none() {
+        let event =
+            load_status_to_event(LoadStatus::HeadParsed, "https://example.com/".to_string());
+        assert!(event.is_none());
     }
 }

--- a/servo_gtk/web_view.rs
+++ b/servo_gtk/web_view.rs
@@ -6,23 +6,55 @@ use crate::key_tables::KeyTables;
 use crate::proto_ipc::{ServoEvent, servo_event};
 use crate::servo_runner::{LogLevel, ServoRunner};
 use glib::info;
+use glib::subclass::Signal;
 use glib::translate::*;
 use gtk::gdk;
 use gtk::prelude::*;
 use gtk::{glib, subclass::prelude::*};
 use image::RgbaImage;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::sync::OnceLock;
 
 const G_LOG_DOMAIN: &str = "ServoGtk";
+
+/// The state of a page load, delivered by the [`WebView::connect_load_changed`]
+/// signal.
+///
+/// Servo only surfaces load start and load completion, so only the
+/// corresponding two states are represented here. Observe [`WebView::uri`]
+/// changes via `notify::uri` for finer-grained navigation events such as
+/// redirects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, glib::Enum)]
+#[enum_type(name = "ServoGtkLoadEvent")]
+pub enum LoadEvent {
+    /// A new load request has started.
+    #[default]
+    Started,
+    /// Loading has finished (all resources loaded, `document.readyState` ==
+    /// `complete`).
+    Finished,
+}
 
 mod imp {
     use super::*;
 
-    #[derive(Default)]
+    #[derive(glib::Properties, Default)]
+    #[properties(wrapper_type = super::WebView)]
     pub struct WebView {
         pub servo_runner: RefCell<Option<ServoRunner>>,
         pub memory_texture: RefCell<Option<gdk::MemoryTexture>>,
         pub key_tables: KeyTables,
+
+        /// The URI of the currently loaded page, or `None` if nothing has been
+        /// loaded yet.
+        #[property(get, name = "uri", nullable)]
+        pub uri: RefCell<Option<String>>,
+        /// The title of the currently loaded page.
+        #[property(get, name = "title", nullable)]
+        pub title: RefCell<Option<String>>,
+        /// Whether the view is currently loading a page.
+        #[property(get, name = "is-loading")]
+        pub is_loading: Cell<bool>,
     }
 
     #[glib::object_subclass]
@@ -32,7 +64,20 @@ mod imp {
         type ParentType = gtk::Widget;
     }
 
+    #[glib::derived_properties]
     impl ObjectImpl for WebView {
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![
+                    // Emitted when the load state of the page changes.
+                    Signal::builder("load-changed")
+                        .param_types([LoadEvent::static_type()])
+                        .build(),
+                ]
+            })
+        }
+
         fn constructed(&self) {
             self.parent_constructed();
 
@@ -223,6 +268,26 @@ impl WebView {
         }
     }
 
+    /// Connect to the `load-changed` signal, emitted when the load state of the
+    /// page changes.
+    ///
+    /// Note: the read-only `uri`, `title`, and `is-loading` properties each
+    /// have a generated getter (`uri()`, `title()`, `is_loading()`) and a
+    /// `notify::` signal (`connect_uri_notify`, `connect_title_notify`,
+    /// `connect_is_loading_notify`).
+    pub fn connect_load_changed<F: Fn(&Self, LoadEvent) + 'static>(
+        &self,
+        f: F,
+    ) -> glib::SignalHandlerId {
+        self.connect_closure(
+            "load-changed",
+            false,
+            glib::closure_local!(move |obj: &Self, event: LoadEvent| {
+                f(obj, event);
+            }),
+        )
+    }
+
     fn translate_event_coordinates(&self, event: &gdk::Event) -> Option<(f64, f64)> {
         let root = gtk::prelude::WidgetExt::root(self)?;
         let native = root.native()?;
@@ -272,15 +337,86 @@ impl WebView {
                     gtk::prelude::WidgetExt::set_cursor(self, Some(&cursor));
                 }
             }
+            servo_event::Event::UrlChanged(url_changed) => {
+                self.set_uri(Some(url_changed.url));
+            }
+            servo_event::Event::TitleChanged(title_changed) => {
+                self.set_title(Some(title_changed.title));
+            }
+            servo_event::Event::LoadStart(load_start) => {
+                if !load_start.url.is_empty() {
+                    self.set_uri(Some(load_start.url));
+                }
+                self.set_is_loading(true);
+                self.emit_load_changed(LoadEvent::Started);
+            }
+            servo_event::Event::LoadEnd(load_end) => {
+                if !load_end.url.is_empty() {
+                    self.set_uri(Some(load_end.url));
+                }
+                self.set_is_loading(false);
+                self.emit_load_changed(LoadEvent::Finished);
+            }
             servo_event::Event::LogMessage(log_msg) => {
                 if let Some(servo_runner) = self.imp().servo_runner.borrow().as_ref() {
                     servo_runner
                         .handle_log_message(LogLevel::from(log_msg.level), &log_msg.message);
                 }
             }
-            _ => {
-                info!("Unhandled event type: {:?}", event_type);
-            }
+        }
+    }
+
+    /// Update the cached `uri` and fire `notify::uri` if it changed.
+    fn set_uri(&self, uri: Option<String>) {
+        let imp = self.imp();
+        if *imp.uri.borrow() != uri {
+            imp.uri.replace(uri);
+            self.notify("uri");
+        }
+    }
+
+    /// Update the cached `title` and fire `notify::title` if it changed.
+    fn set_title(&self, title: Option<String>) {
+        let imp = self.imp();
+        if *imp.title.borrow() != title {
+            imp.title.replace(title);
+            self.notify("title");
+        }
+    }
+
+    /// Update the cached `is-loading` and fire `notify::is-loading` if it
+    /// changed.
+    fn set_is_loading(&self, is_loading: bool) {
+        let imp = self.imp();
+        if imp.is_loading.get() != is_loading {
+            imp.is_loading.set(is_loading);
+            self.notify("is-loading");
+        }
+    }
+
+    fn emit_load_changed(&self, event: LoadEvent) {
+        self.emit_by_name::<()>("load-changed", &[&event]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_event_registers_glib_enum_type() {
+        // Registering the enum type must succeed and be stable across calls.
+        let ty = LoadEvent::static_type();
+        assert_eq!(ty, LoadEvent::static_type());
+        assert_eq!(ty.name(), "ServoGtkLoadEvent");
+    }
+
+    #[test]
+    fn load_event_roundtrips_through_value() {
+        for event in [LoadEvent::Started, LoadEvent::Finished] {
+            let value = event.to_value();
+            let recovered = value.get::<LoadEvent>().expect("value holds a LoadEvent");
+            assert_eq!(event, recovered);
         }
     }
 }


### PR DESCRIPTION
Expose page navigation state on the WebView widget:

- Read-only GObject properties: `uri`, `title`, `is-loading`, each with a generated getter and `notify::` signal.
- A `load-changed` signal carrying a `LoadEvent` (`Started`/`Finished`) glib enum, with a `connect_load_changed` helper.

The runner's WebViewDelegate now implements notify_url_changed, notify_page_title_changed, and notify_load_status_changed, emitting the existing UrlChanged/TitleChanged/LoadStart/LoadEnd IPC events. The WebView translates those into property updates and the load-changed signal. The example browser syncs the window title and URL entry and shows a load spinner via the new API.

Unit tests cover the LoadStatus->event mapping and LoadEvent glib enum registration/Value roundtrip.