### PR TITLE
Add user-content injection and page-to-native message channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6321,6 +6321,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rustls",
+ "serde_json",
  "servo",
  "servo-embedder-traits",
  "surfman 0.9.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ path = "servo_gtk/lib.rs"
 name = "browser"
 path = "examples/browser.rs"
 
+[[example]]
+name = "user_content"
+path = "examples/user_content.rs"
+
 [dependencies]
 gio = "0.22"
 glib = { version = "0.22", features = ["v2_74", "log_macros"] }
@@ -31,6 +35,7 @@ image = "0.25"
 keyboard-types = "0.8"
 prost = "0.13"
 bytes = "1.0"
+serde_json = "1"
 
 [build-dependencies]
 prost-build = "0.13"

--- a/examples/user_content.rs
+++ b/examples/user_content.rs
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Example: user-script injection and the page-to-native message channel.
+//!
+//! This demonstrates the WebKit-style user-content API added to servo-gtk:
+//!
+//! 1. Create a [`UserContentManager`] and construct a [`WebView`] with it via
+//!    [`WebView::with_user_content_manager`].
+//! 2. Register a named message handler and inject a user script that posts a
+//!    message to it — mirroring how a JavaScript SPA talks to its native host.
+//! 3. Receive the message on the native side via the
+//!    `script-message-received` signal and display it.
+//! 4. Trigger `evaluate_javascript` from a button to push a message from
+//!    native to the page (which then posts back).
+//!
+//! The page-to-native call in JavaScript looks like:
+//!
+//! ```js
+//! window.servoGtk.messageHandlers.demo.postMessage({ hello: "native" });
+//! ```
+//!
+//! Run with: `cargo run --example user_content` (requires a display).
+
+use glib::info;
+use gtk::prelude::*;
+use gtk::{Application, ApplicationWindow, Box, Button, Label, Orientation, glib};
+use servo_gtk::{UserContentManager, UserScript, WebView};
+use std::ptr;
+
+const G_LOG_DOMAIN: &str = "ServoGtkUserContent";
+
+const LOGGER: glib::GlibLogger = glib::GlibLogger::new(
+    glib::GlibLoggerFormat::Plain,
+    glib::GlibLoggerDomain::CrateTarget,
+);
+
+/// Name of the message handler the page uses to talk to native.
+const HANDLER_NAME: &str = "demo";
+
+fn main() -> glib::ExitCode {
+    // If this process was spawned as the Servo runner subprocess, hand off to
+    // it immediately. This never returns when running as the runner.
+    servo_gtk::run_as_runner_if_requested();
+
+    log::set_logger(&LOGGER).expect("logger already set");
+    log::set_max_level(log::LevelFilter::Debug);
+
+    info!("Starting ServoGtk user-content example");
+
+    let library = unsafe { libloading::os::unix::Library::new("libepoxy.so.0") }.unwrap();
+    epoxy::load_with(|name| {
+        unsafe { library.get::<_>(name.as_bytes()) }
+            .map(|symbol| *symbol)
+            .unwrap_or(ptr::null())
+    });
+
+    let app = Application::builder()
+        .application_id("com.example.ServoGtkUserContent")
+        .build();
+
+    app.connect_activate(|app| {
+        let window = ApplicationWindow::builder()
+            .application(app)
+            .title("Servo GTK — User Content")
+            .default_width(1024)
+            .default_height(768)
+            .build();
+
+        let vbox = Box::new(Orientation::Vertical, 5);
+
+        // A label showing the most recent message received from the page.
+        let status = Label::new(Some("Waiting for a message from the page…"));
+        status.set_wrap(true);
+        status.set_xalign(0.0);
+
+        // 1. Create the user content manager.
+        let ucm = UserContentManager::new();
+
+        // 2. Register a named handler so page JS can post to it. Injected JS
+        //    can then call:
+        //      window.servoGtk.messageHandlers.demo.postMessage(value)
+        ucm.register_script_message_handler(HANDLER_NAME);
+
+        // Inject a user script that posts a greeting once the page has loaded,
+        // and exposes a helper the "Ping page" button below can invoke.
+        let user_script = UserScript::new(
+            r#"
+            (function () {
+              function post(payload) {
+                window.servoGtk.messageHandlers.demo.postMessage(payload);
+              }
+              // Post an initial message after the document is ready.
+              document.addEventListener('DOMContentLoaded', function () {
+                post({ type: 'HELLO', title: document.title, url: location.href });
+              });
+              // Expose a function native code can call via evaluate_javascript.
+              window.demoPing = function (note) {
+                post({ type: 'PONG', note: note });
+              };
+            })();
+            "#,
+        );
+        ucm.add_script(&user_script);
+
+        // 3. Receive messages from the page on the native side.
+        let status_clone = status.clone();
+        ucm.connect_script_message_received(move |_ucm, name, body| {
+            info!("script message from '{name}': {body}");
+            status_clone.set_text(&format!("Received from '{name}': {body}"));
+        });
+
+        // Construct the WebView with the manager attached.
+        let web_view = WebView::with_user_content_manager(&ucm);
+        web_view.set_hexpand(true);
+        web_view.set_vexpand(true);
+
+        // 4. A button that pushes a message from native to the page by
+        //    evaluating JavaScript; the page's window.demoPing posts back.
+        let ping_button = Button::with_label("Ping page (native → page → native)");
+        let web_view_clone = web_view.clone();
+        ping_button.connect_clicked(move |_| {
+            web_view_clone
+                .evaluate_javascript("window.demoPing && window.demoPing('from native');");
+        });
+
+        let hbox = Box::new(Orientation::Horizontal, 5);
+        hbox.append(&ping_button);
+        hbox.append(&status);
+
+        vbox.append(&hbox);
+        vbox.append(&web_view);
+
+        window.set_child(Some(&vbox));
+        window.present();
+
+        // Load a page. The injected script runs on load and posts the initial
+        // HELLO message back to native.
+        web_view.load_url("https://example.com");
+    });
+
+    app.run()
+}

--- a/proto/ipc.proto
+++ b/proto/ipc.proto
@@ -20,6 +20,13 @@ message ServoAction {
     TouchEnd touch_end = 14;
     TouchCancel touch_cancel = 15;
     bool shutdown = 16;
+    AddUserScript add_user_script = 17;
+    AddUserStyleSheet add_user_style_sheet = 18;
+    bool remove_all_user_scripts = 19;
+    bool remove_all_user_style_sheets = 20;
+    RegisterScriptMessageHandler register_script_message_handler = 21;
+    UnregisterScriptMessageHandler unregister_script_message_handler = 22;
+    EvaluateJavascript evaluate_javascript = 23;
   }
 }
 
@@ -111,6 +118,7 @@ message ServoEvent {
     LoadStart load_start = 5;
     LoadEnd load_end = 6;
     LogMessage log_message = 7;
+    ScriptMessage script_message = 8;
   }
 }
 
@@ -150,4 +158,41 @@ enum LogLevel {
 message LogMessage {
   LogLevel level = 1;
   string message = 2;
+}
+
+// A user script to inject into every page loaded in the WebView. Mirrors the
+// role of WebKitUserScript. Servo does not support injection-time or
+// injected-frames options at this revision, so only the source is carried.
+message AddUserScript {
+  string source = 1;
+}
+
+// A user CSS style sheet to inject into every page loaded in the WebView.
+message AddUserStyleSheet {
+  string source = 1;
+}
+
+// Register a named script message handler. Injected page JavaScript can then
+// call `window.servoGtk.messageHandlers.<name>.postMessage(value)` to send a
+// message to the native side, delivered back as a ScriptMessage event.
+message RegisterScriptMessageHandler {
+  string name = 1;
+}
+
+// Unregister a previously registered named script message handler.
+message UnregisterScriptMessageHandler {
+  string name = 1;
+}
+
+// Evaluate a snippet of JavaScript in the page. Fire-and-forget: the result is
+// not currently returned to the native side.
+message EvaluateJavascript {
+  string source = 1;
+}
+
+// A message sent from page JavaScript to the native side via a registered
+// script message handler. `body` is the JSON-serialized message value.
+message ScriptMessage {
+  string name = 1;
+  string body = 2;
 }

--- a/servo_gtk/lib.rs
+++ b/servo_gtk/lib.rs
@@ -6,8 +6,10 @@ pub mod key_tables;
 pub mod proto_ipc;
 pub mod runner;
 pub mod servo_runner;
+pub mod user_content;
 pub mod web_view;
 
+pub use user_content::{UserContentManager, UserScript, UserStyleSheet};
 pub use web_view::{LoadEvent, WebView};
 
 /// Hand off to the Servo runner subprocess if this process was spawned as one.

--- a/servo_gtk/runner.rs
+++ b/servo_gtk/runner.rs
@@ -21,6 +21,8 @@ use euclid::Point2D;
 use keyboard_types::{Code, Key, KeyState, Location, Modifiers, NamedKey};
 
 use servo::LoadStatus;
+use servo::user_contents::UserStyleSheet;
+use servo::{ConsoleLogLevel, UserContentManager, UserScript};
 use servo::{
     DeviceIntRect, DeviceVector2D, InputEvent, KeyboardEvent, MouseButton, MouseButtonAction,
     MouseButtonEvent, MouseMoveEvent, Scroll, ServoBuilder,
@@ -33,9 +35,17 @@ use std::thread;
 use url::Url;
 
 use crate::proto_ipc::{
-    CursorChanged, FrameReady, LoadEnd, LoadStart, LogLevel, LogMessage, ServoAction, ServoEvent,
-    TitleChanged, UrlChanged, servo_action, servo_event,
+    CursorChanged, FrameReady, LoadEnd, LoadStart, LogLevel, LogMessage, ScriptMessage,
+    ServoAction, ServoEvent, TitleChanged, UrlChanged, servo_action, servo_event,
 };
+
+/// Prefix used by the injected script-message shim when forwarding a page
+/// message to the native side over the console-message bridge. Page messages
+/// are emitted as `console.log("<PREFIX>" + json)` where `json` is
+/// `{"name":<handler>,"body":<value>}`, and the runner detects this prefix in
+/// [`ServoWebViewDelegate::show_console_message`] to re-emit them as
+/// [`ScriptMessage`] events.
+pub(crate) const SCRIPT_MESSAGE_PREFIX: &str = "__servo_gtk_msg__";
 
 /// Marker argument used to signal that the process should run as a Servo
 /// runner subprocess rather than as the host application.
@@ -217,6 +227,63 @@ impl WebViewDelegate for ServoWebViewDelegate {
             let _ = send_event(event);
         }
     }
+
+    fn show_console_message(&self, _webview: WebView, _level: ConsoleLogLevel, message: String) {
+        // Page->native message channel bridge: injected handler shims forward
+        // messages as prefixed console messages. Detect them here and re-emit
+        // as ScriptMessage events. Non-matching console output is ignored (the
+        // separate log-message plumbing handles normal logging).
+        if let Some(event) = parse_script_message(&message) {
+            let _ = send_event(event);
+        }
+    }
+}
+
+/// Parse a console message produced by the injected script-message shim into a
+/// [`ScriptMessage`] event, or `None` if it is not a script message.
+///
+/// The shim emits `"<SCRIPT_MESSAGE_PREFIX>" + JSON.stringify({name, body})`
+/// where `body` is itself the JSON serialization of the value the page passed
+/// to `postMessage`. We forward `name` and the raw JSON `body` string.
+fn parse_script_message(message: &str) -> Option<ServoEvent> {
+    let payload = message.strip_prefix(SCRIPT_MESSAGE_PREFIX)?;
+    let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+    let name = value.get("name")?.as_str()?.to_string();
+    // `body` may be any JSON value; forward its serialized form as a string.
+    let body = match value.get("body") {
+        Some(body) => body.to_string(),
+        None => "null".to_string(),
+    };
+    Some(ServoEvent {
+        event: Some(servo_event::Event::ScriptMessage(ScriptMessage {
+            name,
+            body,
+        })),
+    })
+}
+
+/// Build the JavaScript source for the message-handler shim registered for
+/// `name`. Injected as a user script, it ensures
+/// `window.servoGtk.messageHandlers.<name>.postMessage(value)` forwards the
+/// value to the native side over the console-message bridge.
+fn script_message_handler_shim(name: &str) -> String {
+    // `name` is embedded as a JSON string literal to guard against injection
+    // and to preserve exact handler names.
+    let name_literal = serde_json::to_string(name).unwrap_or_else(|_| "\"\"".to_string());
+    let prefix_literal = serde_json::to_string(SCRIPT_MESSAGE_PREFIX)
+        .unwrap_or_else(|_| "\"__servo_gtk_msg__\"".to_string());
+    format!(
+        r#"(function() {{
+  window.servoGtk = window.servoGtk || {{}};
+  window.servoGtk.messageHandlers = window.servoGtk.messageHandlers || {{}};
+  var name = {name_literal};
+  window.servoGtk.messageHandlers[name] = {{
+    postMessage: function(value) {{
+      console.log({prefix_literal} + JSON.stringify({{ name: name, body: value }}));
+    }}
+  }};
+}})();"#
+    )
 }
 
 /// Map a Servo [`LoadStatus`] to the corresponding [`ServoEvent`], if any.
@@ -325,10 +392,21 @@ pub fn run() {
     let servo_builder = ServoBuilder::default();
     let servo = servo_builder.build();
 
+    // User content manager: backs the parent-side servo_gtk::UserContentManager
+    // API (user-script/style injection and the page->native message channel).
+    let user_content_manager = Rc::new(UserContentManager::new(&servo));
+
     let delegate = Rc::new(ServoWebViewDelegate::new(rendering_context.clone()));
     let webview = WebViewBuilder::new(&servo, rendering_context)
         .delegate(delegate)
+        .user_content_manager(user_content_manager.clone())
         .build();
+
+    // Track the scripts and stylesheets we have added so that we can implement
+    // the bulk `remove_all_*` operations, which Servo's UserContentManager does
+    // not provide natively (it only supports removal by individual handle).
+    let mut user_scripts: Vec<Rc<UserScript>> = Vec::new();
+    let mut user_style_sheets: Vec<Rc<UserStyleSheet>> = Vec::new();
 
     let receiver = spawn_stdin_channel();
 
@@ -503,6 +581,64 @@ pub fn run() {
                     log::info!("Shutting down servo");
                     break;
                 }
+                servo_action::Action::AddUserScript(add_user_script) => {
+                    log::info!(
+                        "Adding user script ({} bytes)",
+                        add_user_script.source.len()
+                    );
+                    let script = Rc::new(UserScript::new(add_user_script.source, None));
+                    user_content_manager.add_script(script.clone());
+                    user_scripts.push(script);
+                }
+                servo_action::Action::AddUserStyleSheet(add_user_style_sheet) => {
+                    log::info!(
+                        "Adding user style sheet ({} bytes)",
+                        add_user_style_sheet.source.len()
+                    );
+                    // Servo requires a URL to identify the stylesheet's origin;
+                    // a synthetic about: URL is sufficient for injected styles.
+                    if let Ok(url) = Url::parse("about:user-stylesheet") {
+                        let stylesheet =
+                            Rc::new(UserStyleSheet::new(add_user_style_sheet.source, url));
+                        user_content_manager.add_stylesheet(stylesheet.clone());
+                        user_style_sheets.push(stylesheet);
+                    }
+                }
+                servo_action::Action::RemoveAllUserScripts(_) => {
+                    log::info!("Removing all user scripts");
+                    for script in user_scripts.drain(..) {
+                        user_content_manager.remove_script(script);
+                    }
+                }
+                servo_action::Action::RemoveAllUserStyleSheets(_) => {
+                    log::info!("Removing all user style sheets");
+                    for stylesheet in user_style_sheets.drain(..) {
+                        user_content_manager.remove_stylesheet(stylesheet);
+                    }
+                }
+                servo_action::Action::RegisterScriptMessageHandler(register) => {
+                    log::info!("Registering script message handler: {}", register.name);
+                    // Inject a shim user script that defines
+                    // window.servoGtk.messageHandlers.<name>.postMessage and
+                    // forwards to native over the console-message bridge.
+                    let shim = script_message_handler_shim(&register.name);
+                    let script = Rc::new(UserScript::new(shim, None));
+                    user_content_manager.add_script(script.clone());
+                    user_scripts.push(script);
+                }
+                servo_action::Action::UnregisterScriptMessageHandler(unregister) => {
+                    log::info!("Unregistering script message handler: {}", unregister.name);
+                    // Servo cannot un-inject an already-applied user script, and
+                    // does not expose per-name script identity. The handler will
+                    // stop being injected once scripts are cleared/reloaded; for
+                    // now this is a no-op beyond logging. Documented divergence.
+                }
+                servo_action::Action::EvaluateJavascript(evaluate) => {
+                    log::debug!("Evaluating JavaScript ({} bytes)", evaluate.source.len());
+                    // Fire-and-forget: the result is not currently returned to
+                    // the native side.
+                    webview.evaluate_javascript(evaluate.source, |_result| {});
+                }
             }
         }
 
@@ -545,5 +681,74 @@ mod tests {
         let event =
             load_status_to_event(LoadStatus::HeadParsed, "https://example.com/".to_string());
         assert!(event.is_none());
+    }
+
+    #[test]
+    fn parse_script_message_ignores_unprefixed_console_output() {
+        assert!(parse_script_message("just a normal log line").is_none());
+        assert!(parse_script_message("").is_none());
+    }
+
+    #[test]
+    fn parse_script_message_extracts_name_and_body_object() {
+        let payload = format!(
+            "{SCRIPT_MESSAGE_PREFIX}{}",
+            r#"{"name":"auth","body":{"type":"TOKEN","value":"abc"}}"#
+        );
+        match parse_script_message(&payload).and_then(|e| e.event) {
+            Some(servo_event::Event::ScriptMessage(msg)) => {
+                assert_eq!(msg.name, "auth");
+                // body is forwarded as its JSON serialization
+                let parsed: serde_json::Value = serde_json::from_str(&msg.body).unwrap();
+                assert_eq!(parsed["type"], "TOKEN");
+                assert_eq!(parsed["value"], "abc");
+            }
+            other => panic!("expected ScriptMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_script_message_handles_string_body() {
+        let payload = format!(
+            "{SCRIPT_MESSAGE_PREFIX}{}",
+            r#"{"name":"h","body":"hello"}"#
+        );
+        match parse_script_message(&payload).and_then(|e| e.event) {
+            Some(servo_event::Event::ScriptMessage(msg)) => {
+                assert_eq!(msg.name, "h");
+                assert_eq!(msg.body, "\"hello\"");
+            }
+            other => panic!("expected ScriptMessage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_script_message_rejects_prefixed_but_invalid_json() {
+        let payload = format!("{SCRIPT_MESSAGE_PREFIX}not json");
+        assert!(parse_script_message(&payload).is_none());
+    }
+
+    #[test]
+    fn parse_script_message_requires_name() {
+        let payload = format!("{SCRIPT_MESSAGE_PREFIX}{}", r#"{"body":1}"#);
+        assert!(parse_script_message(&payload).is_none());
+    }
+
+    #[test]
+    fn shim_embeds_handler_name_and_prefix() {
+        let shim = script_message_handler_shim("myHandler");
+        assert!(shim.contains("window.servoGtk"));
+        assert!(shim.contains("messageHandlers"));
+        assert!(shim.contains("\"myHandler\""));
+        assert!(shim.contains(SCRIPT_MESSAGE_PREFIX));
+        assert!(shim.contains("postMessage"));
+    }
+
+    #[test]
+    fn shim_escapes_quotes_in_handler_name() {
+        // A handler name containing a quote must not break out of the string
+        // literal in the generated JS.
+        let shim = script_message_handler_shim("a\"b");
+        assert!(shim.contains(r#""a\"b""#));
     }
 }

--- a/servo_gtk/servo_runner.rs
+++ b/servo_gtk/servo_runner.rs
@@ -294,6 +294,68 @@ impl ServoRunner {
         });
     }
 
+    pub fn add_user_script(&self, source: &str) {
+        self.send_action(ServoAction {
+            action: Some(servo_action::Action::AddUserScript(
+                crate::proto_ipc::AddUserScript {
+                    source: source.to_string(),
+                },
+            )),
+        });
+    }
+
+    pub fn add_user_style_sheet(&self, source: &str) {
+        self.send_action(ServoAction {
+            action: Some(servo_action::Action::AddUserStyleSheet(
+                crate::proto_ipc::AddUserStyleSheet {
+                    source: source.to_string(),
+                },
+            )),
+        });
+    }
+
+    pub fn remove_all_user_scripts(&self) {
+        self.send_action(ServoAction {
+            action: Some(servo_action::Action::RemoveAllUserScripts(true)),
+        });
+    }
+
+    pub fn remove_all_user_style_sheets(&self) {
+        self.send_action(ServoAction {
+            action: Some(servo_action::Action::RemoveAllUserStyleSheets(true)),
+        });
+    }
+
+    pub fn register_script_message_handler(&self, name: &str) {
+        self.send_action(ServoAction {
+            action: Some(servo_action::Action::RegisterScriptMessageHandler(
+                crate::proto_ipc::RegisterScriptMessageHandler {
+                    name: name.to_string(),
+                },
+            )),
+        });
+    }
+
+    pub fn unregister_script_message_handler(&self, name: &str) {
+        self.send_action(ServoAction {
+            action: Some(servo_action::Action::UnregisterScriptMessageHandler(
+                crate::proto_ipc::UnregisterScriptMessageHandler {
+                    name: name.to_string(),
+                },
+            )),
+        });
+    }
+
+    pub fn evaluate_javascript(&self, source: &str) {
+        self.send_action(ServoAction {
+            action: Some(servo_action::Action::EvaluateJavascript(
+                crate::proto_ipc::EvaluateJavascript {
+                    source: source.to_string(),
+                },
+            )),
+        });
+    }
+
     pub fn handle_log_message(&self, level: LogLevel, message: &str) {
         match level {
             LogLevel::Debug => debug!("{}", message),

--- a/servo_gtk/user_content.rs
+++ b/servo_gtk/user_content.rs
@@ -1,0 +1,313 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! User content injection and the page-to-native message channel.
+//!
+//! This module provides [`UserContentManager`], modelled on WebKitGTK's
+//! `WebKitUserContentManager`. It lets an application inject JavaScript
+//! ([`UserScript`]) and CSS ([`UserStyleSheet`]) into pages loaded in a
+//! [`WebView`](crate::WebView), and register named message handlers that page
+//! JavaScript can call to send messages to the native side.
+//!
+//! # Page-to-native messages
+//!
+//! After [`UserContentManager::register_script_message_handler`] is called with
+//! a name, injected page JavaScript can call:
+//!
+//! ```js
+//! window.servoGtk.messageHandlers.<name>.postMessage(value);
+//! ```
+//!
+//! and the value is delivered to the native side via the
+//! [`script-message-received`](UserContentManager::connect_script_message_received)
+//! signal, with `body` being the JSON serialization of `value`.
+//!
+//! # Differences from WebKitGTK
+//!
+//! Servo (at the revision this library targets) has no native script-message
+//! API, so the channel is implemented over Servo's console-message hook: the
+//! registered handler is a small injected shim that forwards messages as
+//! prefixed console messages, which the runner detects and re-emits. As a
+//! consequence:
+//!
+//! - The JavaScript entry point is `window.servoGtk.messageHandlers`, not
+//!   `window.webkit.messageHandlers` (there is no `webkit` alias).
+//! - [`UserScript`] carries only a source string; WebKit's injection-time and
+//!   injected-frames options are not available in Servo at this revision.
+//! - Reply handlers and script worlds are not supported.
+//! - User content changes take effect on the next page load.
+
+use glib::prelude::*;
+use glib::subclass::Signal;
+use gtk::glib;
+use gtk::subclass::prelude::*;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::OnceLock;
+
+use crate::servo_runner::ServoRunner;
+
+/// A JavaScript snippet to inject into pages loaded in a
+/// [`WebView`](crate::WebView). Analogous to WebKitGTK's `WebKitUserScript`,
+/// but carrying only a source string.
+#[derive(Debug, Clone)]
+pub struct UserScript {
+    source: String,
+}
+
+impl UserScript {
+    /// Create a user script from the given JavaScript source.
+    pub fn new(source: &str) -> Self {
+        Self {
+            source: source.to_string(),
+        }
+    }
+
+    /// The JavaScript source of this user script.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+}
+
+/// A CSS style sheet to inject into pages loaded in a
+/// [`WebView`](crate::WebView). Analogous to WebKitGTK's `WebKitUserStyleSheet`,
+/// but carrying only a source string.
+#[derive(Debug, Clone)]
+pub struct UserStyleSheet {
+    source: String,
+}
+
+impl UserStyleSheet {
+    /// Create a user style sheet from the given CSS source.
+    pub fn new(source: &str) -> Self {
+        Self {
+            source: source.to_string(),
+        }
+    }
+
+    /// The CSS source of this user style sheet.
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+}
+
+/// A buffered user-content action, applied to the [`WebView`]'s runner once the
+/// manager is attached to a [`WebView`].
+#[derive(Debug, Clone)]
+pub(crate) enum PendingAction {
+    AddScript(String),
+    AddStyleSheet(String),
+    RemoveAllScripts,
+    RemoveAllStyleSheets,
+    RegisterHandler(String),
+    UnregisterHandler(String),
+}
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct UserContentManager {
+        /// The runner this manager forwards actions to, once attached to a
+        /// [`WebView`](crate::WebView). The manager holds only this runner
+        /// handle, not the `WebView` itself.
+        pub(crate) runner: RefCell<Option<Rc<ServoRunner>>>,
+        /// Actions requested before the manager was attached to a runner.
+        /// Flushed in order once attached.
+        pub(crate) pending: RefCell<Vec<PendingAction>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for UserContentManager {
+        const NAME: &'static str = "ServoGtkUserContentManager";
+        type Type = super::UserContentManager;
+        type ParentType = glib::Object;
+    }
+
+    impl ObjectImpl for UserContentManager {
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![
+                    // Emitted when page JavaScript sends a message through a
+                    // registered handler. Parameters: handler name, JSON body.
+                    Signal::builder("script-message-received")
+                        .param_types([String::static_type(), String::static_type()])
+                        .build(),
+                ]
+            })
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct UserContentManager(ObjectSubclass<imp::UserContentManager>);
+}
+
+impl Default for UserContentManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UserContentManager {
+    /// Create a new, empty user content manager.
+    pub fn new() -> Self {
+        glib::Object::builder().build()
+    }
+
+    /// Inject a [`UserScript`] into pages loaded in the associated
+    /// [`WebView`]. Takes effect on the next page load.
+    pub fn add_script(&self, script: &UserScript) {
+        self.dispatch(PendingAction::AddScript(script.source().to_string()));
+    }
+
+    /// Inject a [`UserStyleSheet`] into pages loaded in the associated
+    /// [`WebView`]. Takes effect on the next page load.
+    pub fn add_style_sheet(&self, style_sheet: &UserStyleSheet) {
+        self.dispatch(PendingAction::AddStyleSheet(
+            style_sheet.source().to_string(),
+        ));
+    }
+
+    /// Remove all user scripts previously added to this manager.
+    pub fn remove_all_scripts(&self) {
+        self.dispatch(PendingAction::RemoveAllScripts);
+    }
+
+    /// Remove all user style sheets previously added to this manager.
+    pub fn remove_all_style_sheets(&self) {
+        self.dispatch(PendingAction::RemoveAllStyleSheets);
+    }
+
+    /// Register a named script message handler. After this, page JavaScript
+    /// can call `window.servoGtk.messageHandlers.<name>.postMessage(value)` to
+    /// deliver a message to the native side via the
+    /// [`script-message-received`](Self::connect_script_message_received)
+    /// signal. Takes effect on the next page load.
+    pub fn register_script_message_handler(&self, name: &str) {
+        self.dispatch(PendingAction::RegisterHandler(name.to_string()));
+    }
+
+    /// Unregister a previously registered named script message handler.
+    ///
+    /// Note: Servo cannot un-inject an already-applied handler shim, so this
+    /// only prevents future injection; existing pages keep the handler until
+    /// reloaded.
+    pub fn unregister_script_message_handler(&self, name: &str) {
+        self.dispatch(PendingAction::UnregisterHandler(name.to_string()));
+    }
+
+    /// Connect to the `script-message-received` signal, emitted when page
+    /// JavaScript posts a message through a registered handler. The closure
+    /// receives the handler `name` and the JSON-serialized message `body`.
+    pub fn connect_script_message_received<F: Fn(&Self, &str, &str) + 'static>(
+        &self,
+        f: F,
+    ) -> glib::SignalHandlerId {
+        self.connect_closure(
+            "script-message-received",
+            false,
+            glib::closure_local!(move |obj: &Self, name: String, body: String| {
+                f(obj, &name, &body);
+            }),
+        )
+    }
+
+    /// Attach this manager to a [`WebView`](crate::WebView)'s runner, flushing
+    /// any buffered actions. Called by `WebView` construction; not part of the
+    /// public API.
+    pub(crate) fn attach(&self, runner: Rc<ServoRunner>) {
+        self.imp().runner.replace(Some(runner));
+        // Flush buffered actions in order.
+        let pending: Vec<PendingAction> = self.imp().pending.borrow_mut().drain(..).collect();
+        for action in pending {
+            self.apply(&action);
+        }
+    }
+
+    /// Emit the `script-message-received` signal. Called by
+    /// [`WebView`](crate::WebView) when a ScriptMessage event arrives from the
+    /// runner.
+    pub(crate) fn emit_script_message(&self, name: &str, body: &str) {
+        self.emit_by_name::<()>("script-message-received", &[&name, &body]);
+    }
+
+    /// Forward an action to the attached runner, or buffer it if not yet
+    /// attached.
+    fn dispatch(&self, action: PendingAction) {
+        if self.imp().runner.borrow().is_some() {
+            self.apply(&action);
+        } else {
+            self.imp().pending.borrow_mut().push(action);
+        }
+    }
+
+    fn apply(&self, action: &PendingAction) {
+        let runner = self.imp().runner.borrow();
+        let Some(runner) = runner.as_ref() else {
+            return;
+        };
+        match action {
+            PendingAction::AddScript(source) => runner.add_user_script(source),
+            PendingAction::AddStyleSheet(source) => runner.add_user_style_sheet(source),
+            PendingAction::RemoveAllScripts => runner.remove_all_user_scripts(),
+            PendingAction::RemoveAllStyleSheets => runner.remove_all_user_style_sheets(),
+            PendingAction::RegisterHandler(name) => runner.register_script_message_handler(name),
+            PendingAction::UnregisterHandler(name) => {
+                runner.unregister_script_message_handler(name)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_script_and_style_sheet_carry_source() {
+        let script = UserScript::new("console.log('hi')");
+        assert_eq!(script.source(), "console.log('hi')");
+        let sheet = UserStyleSheet::new("body { color: red }");
+        assert_eq!(sheet.source(), "body { color: red }");
+    }
+
+    #[test]
+    fn manager_registers_signal() {
+        let ucm = UserContentManager::new();
+        // Connecting to the signal must succeed (signal is registered).
+        let _id = ucm.connect_script_message_received(|_, _, _| {});
+    }
+
+    #[test]
+    fn actions_are_buffered_before_attach() {
+        let ucm = UserContentManager::new();
+        ucm.add_script(&UserScript::new("1"));
+        ucm.add_style_sheet(&UserStyleSheet::new("2"));
+        ucm.register_script_message_handler("h");
+        // Not attached to a runner yet, so all actions should be buffered.
+        assert_eq!(ucm.imp().pending.borrow().len(), 3);
+    }
+
+    #[test]
+    fn script_message_signal_delivers_name_and_body() {
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        let ucm = UserContentManager::new();
+        let received = Rc::new(RefCell::new(None));
+        let received_clone = received.clone();
+        ucm.connect_script_message_received(move |_, name, body| {
+            *received_clone.borrow_mut() = Some((name.to_string(), body.to_string()));
+        });
+
+        ucm.emit_script_message("auth", r#"{"token":"abc"}"#);
+
+        assert_eq!(
+            *received.borrow(),
+            Some(("auth".to_string(), r#"{"token":"abc"}"#.to_string()))
+        );
+    }
+}

--- a/servo_gtk/web_view.rs
+++ b/servo_gtk/web_view.rs
@@ -5,6 +5,7 @@
 use crate::key_tables::KeyTables;
 use crate::proto_ipc::{ServoEvent, servo_event};
 use crate::servo_runner::{LogLevel, ServoRunner};
+use crate::user_content::UserContentManager;
 use glib::info;
 use glib::subclass::Signal;
 use glib::translate::*;
@@ -13,6 +14,7 @@ use gtk::prelude::*;
 use gtk::{glib, subclass::prelude::*};
 use image::RgbaImage;
 use std::cell::{Cell, RefCell};
+use std::rc::Rc;
 use std::sync::OnceLock;
 
 const G_LOG_DOMAIN: &str = "ServoGtk";
@@ -41,9 +43,11 @@ mod imp {
     #[derive(glib::Properties, Default)]
     #[properties(wrapper_type = super::WebView)]
     pub struct WebView {
-        pub servo_runner: RefCell<Option<ServoRunner>>,
+        pub servo_runner: RefCell<Option<Rc<ServoRunner>>>,
         pub memory_texture: RefCell<Option<gdk::MemoryTexture>>,
         pub key_tables: KeyTables,
+        /// The user content manager attached to this WebView, if any.
+        pub user_content_manager: RefCell<Option<UserContentManager>>,
 
         /// The URI of the currently loaded page, or `None` if nothing has been
         /// loaded yet.
@@ -84,7 +88,7 @@ mod imp {
             let servo_runner = ServoRunner::new();
             let event_receiver = servo_runner.event_receiver();
 
-            self.servo_runner.replace(Some(servo_runner));
+            self.servo_runner.replace(Some(Rc::new(servo_runner)));
 
             let obj_weak = self.obj().downgrade();
             glib::spawn_future_local(async move {
@@ -240,6 +244,44 @@ impl WebView {
         glib::Object::builder().build()
     }
 
+    /// Create a `WebView` with an attached [`UserContentManager`], enabling
+    /// user-script/style injection and the page-to-native message channel.
+    ///
+    /// Analogous to constructing a `WebKitWebView` with a
+    /// `WebKitUserContentManager`. Any scripts, style sheets, or message
+    /// handlers added to the manager before or after this call take effect on
+    /// the next page load.
+    pub fn with_user_content_manager(user_content_manager: &UserContentManager) -> Self {
+        let web_view: Self = glib::Object::builder().build();
+        // Hand the manager a handle to this WebView's runner so it can forward
+        // user-content actions directly, then flush anything buffered before
+        // attach. The manager depends only on the runner, not on the WebView.
+        if let Some(runner) = web_view.imp().servo_runner.borrow().as_ref() {
+            user_content_manager.attach(runner.clone());
+        }
+        web_view
+            .imp()
+            .user_content_manager
+            .replace(Some(user_content_manager.clone()));
+        web_view
+    }
+
+    /// The [`UserContentManager`] attached to this `WebView`, if any.
+    pub fn user_content_manager(&self) -> Option<UserContentManager> {
+        self.imp().user_content_manager.borrow().clone()
+    }
+
+    /// Evaluate a snippet of JavaScript in the currently loaded page.
+    ///
+    /// Fire-and-forget: the result of the evaluation is not currently returned
+    /// to the caller. Analogous to `webkit_web_view_evaluate_javascript()`.
+    pub fn evaluate_javascript(&self, script: &str) {
+        let imp = self.imp();
+        if let Some(servo) = imp.servo_runner.borrow().as_ref() {
+            servo.evaluate_javascript(script);
+        }
+    }
+
     pub fn load_url(&self, url: &str) {
         let imp = self.imp();
         if let Some(servo) = imp.servo_runner.borrow().as_ref() {
@@ -361,6 +403,11 @@ impl WebView {
                 if let Some(servo_runner) = self.imp().servo_runner.borrow().as_ref() {
                     servo_runner
                         .handle_log_message(LogLevel::from(log_msg.level), &log_msg.message);
+                }
+            }
+            servo_event::Event::ScriptMessage(script_message) => {
+                if let Some(ucm) = self.imp().user_content_manager.borrow().as_ref() {
+                    ucm.emit_script_message(&script_message.name, &script_message.body);
                 }
             }
         }


### PR DESCRIPTION
Add a WebKitGTK-style UserContentManager to servo-gtk so applications can inject JavaScript and CSS into loaded pages and exchange messages with an embedded JS SPA (the enabler for the WorkSpaces WarpDrive/SAML flow).

New public API (modelled on WebKitUserContentManager):
- UserContentManager GObject with add_script / add_style_sheet / remove_all_scripts / remove_all_style_sheets / register_script_message_handler / unregister_script_message_handler and the script-message-received signal (connect_script_message_received).
- UserScript / UserStyleSheet value types (source only).
- WebView::with_user_content_manager(&ucm), WebView::user_content_manager(), WebView::evaluate_javascript(&str).

Page-to-native channel: page JS calls
  window.servoGtk.messageHandlers.<name>.postMessage(value) and native receives (name, json-body) via script-message-received.

Servo rev e8dbc1d capability notes (investigation):
- Servo HAS a real UserContentManager (add_script/remove_script/ add_stylesheet/remove_stylesheet), UserScript, UserStyleSheet, attached via WebViewBuilder::user_content_manager; and WebView::evaluate_javascript with an async JSValue result callback. These back the injection + eval API directly.
- Servo has NO native script-message handler API (no window.webkit .messageHandlers equivalent). The page-to-native channel is therefore bridged over Servo's WebViewDelegate::show_console_message hook: the registered handler is an injected shim that forwards messages as prefixed console messages, which the runner detects and re-emits as ScriptMessage IPC events.
- Divergences from WebKitGTK, by Servo limitation: JS entry point is window.servoGtk (no webkit alias); UserScript has no injection-time / injected-frames options; no reply-handlers or script worlds; user content applies on next page load; evaluate_javascript is fire-and-forget (result not yet returned).

Mechanism mirrors the d3782c1 navigation API: proto messages (ServoAction Add/Remove/Register/Unregister/EvaluateJavascript + ServoEvent ScriptMessage) -> runner emit/handle -> WebView / UserContentManager signal & methods.

Tests cover the console-bridge parse helper, the handler shim, and the UserContentManager signal/buffering (non-display). A dedicated examples/user_content.rs demonstrates injection, messaging, and eval.