### PR TITLE
Minor performance improvement by using a non-reallocating protobuf serialization

### DIFF
--- a/servo_gtk/proto_ipc.rs
+++ b/servo_gtk/proto_ipc.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 use prost::Message;
 
 include!(concat!(env!("OUT_DIR"), "/servo_ipc.rs"));

--- a/servo_gtk/proto_ipc.rs
+++ b/servo_gtk/proto_ipc.rs
@@ -7,24 +7,12 @@ use prost::Message;
 include!(concat!(env!("OUT_DIR"), "/servo_ipc.rs"));
 
 impl ServoAction {
-    pub fn encode_to_vec(&self) -> Vec<u8> {
-        let mut buf = Vec::new();
-        self.encode(&mut buf).unwrap();
-        buf
-    }
-
     pub fn decode_from_slice(buf: &[u8]) -> Result<Self, prost::DecodeError> {
         Self::decode(buf)
     }
 }
 
 impl ServoEvent {
-    pub fn encode_to_vec(&self) -> Vec<u8> {
-        let mut buf = Vec::new();
-        self.encode(&mut buf).unwrap();
-        buf
-    }
-
     pub fn decode_from_slice(buf: &[u8]) -> Result<Self, prost::DecodeError> {
         Self::decode(buf)
     }

--- a/servo_gtk/runner.rs
+++ b/servo_gtk/runner.rs
@@ -19,6 +19,7 @@ use dpi::PhysicalSize;
 use embedder_traits::{WebViewPoint, WebViewVector};
 use euclid::Point2D;
 use keyboard_types::{Code, Key, KeyState, Location, Modifiers, NamedKey};
+use prost::Message;
 
 use servo::{
     DeviceIntRect, DeviceVector2D, InputEvent, KeyboardEvent, MouseButton, MouseButtonAction,

--- a/servo_gtk/servo_runner.rs
+++ b/servo_gtk/servo_runner.rs
@@ -7,6 +7,7 @@ use async_channel;
 use gio::prelude::*;
 use gio::{OutputStream, Subprocess, SubprocessFlags, SubprocessLauncher};
 use glib::{debug, error, info, warn};
+use prost::Message;
 use std::ffi::OsStr;
 
 use crate::proto_ipc::{ServoAction, ServoEvent, servo_action};


### PR DESCRIPTION
ServoAction and ServoEvent each defined an inherent encode_to_vec that
encoded into a Vec::new(). These took precendence over Message::encode_to_vec
and erroneously used Message::encode which does not preallocate upfront.

This deletes both methods and brings the trait into scope at the call sites.